### PR TITLE
Fix redirect after deleting ISSN publication from request

### DIFF
--- a/src/frontend/components/issn-registry/subComponents/modals/IssnPublicationsModal.jsx
+++ b/src/frontend/components/issn-registry/subComponents/modals/IssnPublicationsModal.jsx
@@ -68,9 +68,13 @@ function IssnPublicationsModal(props) {
     updateSearchBody({limit: rowsPerPage, offset: 0});
   }
 
-  // Event handler for viewing a single publication
-  const handleTableRowClick = (id) => {
-    history.push(`/issn-registry/publications/${id}`);
+  // Handles click on a table row - view single publication details
+  const handleViewSinglePublication = (id) => {
+    history.push(`/issn-registry/publications/${id}`, {
+      // pass request or publisher id for successful redirect after publication is deleted
+      requestId: searchAttribute === 'formId' ? searchValue : null,
+      publisherId: searchAttribute === 'publisherId' ? searchValue : null
+    });
   };
 
   function updatePageNumber(pageIdx) {
@@ -116,7 +120,7 @@ function IssnPublicationsModal(props) {
         <TableComponent
           pagination
           data={data.results.map(filterDataFields)}
-          handleTableRowClick={handleTableRowClick}
+          handleTableRowClick={handleViewSinglePublication}
           headRows={headRows}
           page={searchBody.offset !== 0 ? searchBody.offset / searchBody.limit : 0}
           setPage={updatePageNumber}

--- a/src/frontend/views/issn-registry/publications/IssnPublication.jsx
+++ b/src/frontend/views/issn-registry/publications/IssnPublication.jsx
@@ -126,6 +126,22 @@ function IssnPublication(props) {
     setLoading(false);
   }
 
+  /* Handles redirecting to the right page after publication is deleted */
+  function getRedirectRoute () {
+    // When coming from single request page via publications modal - redirect back to single request page
+    if (history.location.state?.requestId) {
+      return `/issn-registry/requests/${history.location.state.requestId}`;
+    }
+
+    // When coming from publisher page via publications modal - redirect back to publisher page
+    if(history.location.state?.publisherId) {
+      return `/issn-registry/publishers/${history.location.state.publisherId}`;
+    }
+
+    // Otherwise redirect back to publications page (default)
+    return '/issn-registry/publications';
+  }
+
   /* Handles going back to the previous page */
   const handleGoBack = () => {
     // Keep search state if previous page was search page
@@ -171,7 +187,7 @@ function IssnPublication(props) {
       url: `/api/issn-registry/publications/${id}`,
       authenticationToken,
       history,
-      redirectRoute: '/issn-registry/publications',
+      redirectRoute: getRedirectRoute(),
       setSnackbarMessage
     });
 


### PR DESCRIPTION
Fixed redirect after deleting ISSN publication **KBDEV-985**:
- when coming via modal from the request page
- when coming via modal from the publisher page