### PR TITLE
Rearrange and unify elements

### DIFF
--- a/src/frontend/components/isbn-registry/publicationRequests/IsbnPublicationRequestDataComponent.jsx
+++ b/src/frontend/components/isbn-registry/publicationRequests/IsbnPublicationRequestDataComponent.jsx
@@ -710,33 +710,38 @@ function IsbnPublicationRequestDataComponent(props) {
         )}
       </div>
 
-      {/* Muut tiedot - Other details*/}
-      <div className="listComponentContainer listComponentOtherReference">
+      {/* Julkaisun lisätiedot - Publication additional details*/}
+      <div className="listComponentContainer listComponentPublicationDetails">
         <Typography variant="h6" className="listComponentContainerHeader">
-          <FormattedMessage id="form.common.otherInfo" />
+          <FormattedMessage id="common.publicationDetails" />
         </Typography>
         <ListComponent
-          edit={false}
-          label={<FormattedMessage id="form.common.createdBy" />}
-          value={currentRequest.createdBy}
+          edit={isEdit && isEditable('publicationsPublic')}
+          fieldName="publicationsPublic"
+          label={<FormattedMessage id="request.publication.isPublic" />}
+          value={intl.formatMessage({id: `common.${currentRequest.publicationsPublic}`})}
         />
         <ListComponent
-          edit={false}
-          fieldName="timestamp"
-          label={<FormattedMessage id="form.common.created" />}
-          value={currentRequest.created}
+          edit={isEdit && isEditable('publicationsIntra')}
+          fieldName="publicationsIntra"
+          label={<FormattedMessage id="request.publication.publicationsIntra" />}
+          value={intl.formatMessage({id: `common.${currentRequest.publicationsIntra}`})}
         />
         <ListComponent
-          edit={false}
-          label={<FormattedMessage id="form.common.modifiedBy" />}
-          value={currentRequest.modifiedBy}
+          edit={isEdit && isEditable('publicationType')}
+          fieldName="publicationType"
+          label={<FormattedMessage id="form.common.format" />}
+          value={intl.formatMessage({id: `common.${currentRequest.publicationType}`})}
+          publication="isbn-ismn"
         />
-        <ListComponent
-          edit={false}
-          fieldName="timestamp"
-          label={<FormattedMessage id="form.common.modified" />}
-          value={currentRequest.modified}
-        />
+        {currentRequest.publicationType === 'MAP' && (
+          <ListComponent
+            edit={isEdit && isEditable('mapScale')}
+            fieldName="mapScale"
+            label={<FormattedMessage id="form.common.scale" />}
+            value={currentRequest.mapScale}
+          />
+        )}
       </div>
 
       {/* Sarjan tiedot - Series details*/}
@@ -783,38 +788,33 @@ function IsbnPublicationRequestDataComponent(props) {
         />
       </div>
 
-      {/* Julkaisun lisätiedot - Publication additional details*/}
-      <div className="listComponentContainer listComponentPublicationDetails">
+      {/* Muut tiedot - Other details*/}
+      <div className="listComponentContainer listComponentOtherReference">
         <Typography variant="h6" className="listComponentContainerHeader">
-          <FormattedMessage id="common.publicationDetails" />
+          <FormattedMessage id="form.common.otherInfo" />
         </Typography>
         <ListComponent
-          edit={isEdit && isEditable('publicationsPublic')}
-          fieldName="publicationsPublic"
-          label={<FormattedMessage id="request.publication.isPublic" />}
-          value={intl.formatMessage({id: `common.${currentRequest.publicationsPublic}`})}
+          edit={false}
+          label={<FormattedMessage id="form.common.createdBy" />}
+          value={currentRequest.createdBy}
         />
         <ListComponent
-          edit={isEdit && isEditable('publicationsIntra')}
-          fieldName="publicationsIntra"
-          label={<FormattedMessage id="request.publication.publicationsIntra" />}
-          value={intl.formatMessage({id: `common.${currentRequest.publicationsIntra}`})}
+          edit={false}
+          fieldName="timestamp"
+          label={<FormattedMessage id="form.common.created" />}
+          value={currentRequest.created}
         />
         <ListComponent
-          edit={isEdit && isEditable('publicationType')}
-          fieldName="publicationType"
-          label={<FormattedMessage id="form.common.format" />}
-          value={intl.formatMessage({id: `common.${currentRequest.publicationType}`})}
-          publication="isbn-ismn"
+          edit={false}
+          label={<FormattedMessage id="form.common.modifiedBy" />}
+          value={currentRequest.modifiedBy}
         />
-        {currentRequest.publicationType === 'MAP' && (
-          <ListComponent
-            edit={isEdit && isEditable('mapScale')}
-            fieldName="mapScale"
-            label={<FormattedMessage id="form.common.scale" />}
-            value={currentRequest.mapScale}
-          />
-        )}
+        <ListComponent
+          edit={false}
+          fieldName="timestamp"
+          label={<FormattedMessage id="form.common.modified" />}
+          value={currentRequest.modified}
+        />
       </div>
     </div>
   );

--- a/src/frontend/components/isbn-registry/publicationRequests/IsbnPublicationRequestDataComponent.jsx
+++ b/src/frontend/components/isbn-registry/publicationRequests/IsbnPublicationRequestDataComponent.jsx
@@ -430,6 +430,12 @@ function IsbnPublicationRequestDataComponent(props) {
           value={currentRequest.address}
         />
         <ListComponent
+          edit={isEdit && isEditable('zip')}
+          fieldName="zip"
+          label={<FormattedMessage id="form.common.zip" />}
+          value={currentRequest.zip}
+        />
+        <ListComponent
           edit={isEdit && isEditable('city')}
           fieldName="city"
           label={<FormattedMessage id="form.common.city" />}
@@ -440,12 +446,6 @@ function IsbnPublicationRequestDataComponent(props) {
           fieldName="locality"
           label={<FormattedMessage id="request.publication.locality" />}
           value={currentRequest.locality}
-        />
-        <ListComponent
-          edit={isEdit && isEditable('zip')}
-          fieldName="zip"
-          label={<FormattedMessage id="form.common.zip" />}
-          value={currentRequest.zip}
         />
         <ListComponent
           edit={isEdit && isEditable('phone')}

--- a/src/frontend/components/isbn-registry/publisher/IsbnPublisherDataComponent.jsx
+++ b/src/frontend/components/isbn-registry/publisher/IsbnPublisherDataComponent.jsx
@@ -138,16 +138,16 @@ function IsbnPublisherDataComponent({isEdit, publisher, clearFields, history, in
           value={publisher.addressLine1 ?? ''}
         />
         <ListComponent
-          edit={isEdit && isEditable('city')}
-          fieldName="city"
-          label={<FormattedMessage id="form.common.city" />}
-          value={publisher.city ?? ''}
-        />
-        <ListComponent
           edit={isEdit && isEditable('zip')}
           fieldName="zip"
           label={<FormattedMessage id="form.common.zip" />}
           value={publisher.zip ?? ''}
+        />
+        <ListComponent
+          edit={isEdit && isEditable('city')}
+          fieldName="city"
+          label={<FormattedMessage id="form.common.city" />}
+          value={publisher.city ?? ''}
         />
       </div>
       <div className="listComponentContainer">

--- a/src/frontend/components/isbn-registry/subComponents/modals/SavePublisherModal/PublicationRequestDetails.jsx
+++ b/src/frontend/components/isbn-registry/subComponents/modals/SavePublisherModal/PublicationRequestDetails.jsx
@@ -126,6 +126,12 @@ function PublisherDetails ({publicationRequest}) {
           </div>
           <div>
             <Typography>
+              <FormattedMessage id="form.common.zip" />:
+            </Typography>
+            <Typography>{publicationRequest?.zip}</Typography>
+          </div>
+          <div>
+            <Typography>
               <FormattedMessage id="form.common.city" />:
             </Typography>
             <Typography>{publicationRequest?.city}</Typography>
@@ -135,12 +141,6 @@ function PublisherDetails ({publicationRequest}) {
               <FormattedMessage id="request.publication.locality" />:
             </Typography>
             <Typography>{publicationRequest?.locality ?? '-'}</Typography>
-          </div>
-          <div>
-            <Typography>
-              <FormattedMessage id="form.common.zip" />:
-            </Typography>
-            <Typography>{publicationRequest?.zip}</Typography>
           </div>
           <div>
             <Typography>

--- a/src/frontend/components/issn-registry/publishers/IssnPublisherDataComponent.jsx
+++ b/src/frontend/components/issn-registry/publishers/IssnPublisherDataComponent.jsx
@@ -122,16 +122,16 @@ function IssnPublisherDataComponent(props) {
           value={publisher.address ?? ''}
         />
         <ListComponent
-          edit={isEdit && isEditable('city')}
-          fieldName="city"
-          label={<FormattedMessage id="form.common.city" />}
-          value={publisher.city ?? ''}
-        />
-        <ListComponent
           edit={isEdit && isEditable('zip')}
           fieldName="zip"
           label={<FormattedMessage id="form.common.zip" />}
           value={publisher.zip ?? ''}
+        />
+        <ListComponent
+          edit={isEdit && isEditable('city')}
+          fieldName="city"
+          label={<FormattedMessage id="form.common.city" />}
+          value={publisher.city ?? ''}
         />
       </div>
       <div className="listComponentContainer">

--- a/src/frontend/components/issn-registry/subComponents/modals/IssnRequestArchiveModal.jsx
+++ b/src/frontend/components/issn-registry/subComponents/modals/IssnRequestArchiveModal.jsx
@@ -98,15 +98,15 @@ function IssnRequestArchiveModal({formId, userInfo}) {
           </div>
           <div>
             <Typography>
-              <FormattedMessage id="form.common.city" />:
-            </Typography>{' '}
-            <p>{data.city}</p>
-          </div>
-          <div>
-            <Typography>
               <FormattedMessage id="form.common.zip" />:
             </Typography>{' '}
             <p>{data.zip}</p>
+          </div>
+          <div>
+            <Typography>
+              <FormattedMessage id="form.common.city" />:
+            </Typography>{' '}
+            <p>{data.city}</p>
           </div>
           <div>
             <Typography>

--- a/src/frontend/css/common.css
+++ b/src/frontend/css/common.css
@@ -111,6 +111,9 @@
 }
 
 .updateButtonsContainer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
   margin: 1rem 0;
 }
 

--- a/src/frontend/css/common.css
+++ b/src/frontend/css/common.css
@@ -24,13 +24,13 @@
 /* Preserve the desired order of data blocks on the isbn request preview page */
 .listComponentAuthors,
 .listComponentSeriesDetails,
-.listComponentPublicationDetails {
+.listComponentOtherReference {
   grid-column: 2 / 3;
 }
 
 .listComponentAdditionalDetails,
 .listComponentFormManagement,
-.listComponentOtherReference {
+.listComponentPublicationDetails {
   grid-column: 1 / 2;
 }
 

--- a/src/frontend/css/requests/isbnIsmn/request.css
+++ b/src/frontend/css/requests/isbnIsmn/request.css
@@ -69,6 +69,12 @@
   aspect-ratio: 3/1;
 }
 
+div.dialogButtons {
+  display: flex;
+  justify-content: space-evenly;
+  padding-bottom: 1rem;
+}
+
 @media (max-width: 1600px) {
   .requestButton {
     width: 7.5rem;

--- a/src/frontend/css/requests/isbnIsmn/request.css
+++ b/src/frontend/css/requests/isbnIsmn/request.css
@@ -12,6 +12,10 @@
   margin: 3rem 0;
 }
 
+.requestButtonsContainer:has(.grantAnIdButtonsContainer) {
+  display: flex;
+}
+
 .issnPublicationButtonsContainer {
   display: flex;
   justify-content: space-between;
@@ -27,7 +31,7 @@
 
 .grantAnIdButtonsContainer {
   display: flex;
-  gap: 10px;
+  gap: 0.75rem;
 }
 
 .grantAnIdModal {

--- a/src/frontend/css/requests/isbnIsmn/request.css
+++ b/src/frontend/css/requests/isbnIsmn/request.css
@@ -1,9 +1,3 @@
-.btnContainer {
-  display: flex;
-  min-width: 90%;
-  margin: 2rem 0;
-}
-
 .requestButtonsContainer  {
   display: grid;
   place-items: center;
@@ -75,18 +69,6 @@
   aspect-ratio: 3/1;
 }
 
-@media (min-width: 1350px) {
-  .btnContainer {
-    width: 120px;
-  }
-}
-
-@media (min-width: 1200px) {
-  .btnContainer {
-    min-width: 80%;
-  }
-}
-
 @media (max-width: 1600px) {
   .requestButton {
     width: 7.5rem;
@@ -124,11 +106,5 @@
 @media (max-width: 760px) {
   .tabsContainer p {
     display: none;
-  }
-}
-
-@media (max-width: 750px) {
-  .btnContainer {
-    min-width: 50%;
   }
 }

--- a/src/frontend/views/isbn-registry/messagetemplates/IsbnMessageTemplateForm.jsx
+++ b/src/frontend/views/isbn-registry/messagetemplates/IsbnMessageTemplateForm.jsx
@@ -144,20 +144,20 @@ function IsbnMessageTemplateForm(props) {
             />
             <div className="templateFormButtons">
               <Button
-                type="button"
-                variant="contained"
-                color="primary"
-                onClick={handleCancel}
-              >
-                <FormattedMessage id="form.button.label.cancel" />
-              </Button>
-              <Button
                 disabled={pristine || !valid}
                 type="submit"
                 variant="contained"
                 color="success"
               >
                 <FormattedMessage id="form.button.label.create" />
+              </Button>
+              <Button
+                type="button"
+                variant="contained"
+                color="primary"
+                onClick={handleCancel}
+              >
+                <FormattedMessage id="form.button.label.cancel" />
               </Button>
             </div>
           </form>

--- a/src/frontend/views/isbn-registry/publisher-ranges/IsbnPublisherRange.jsx
+++ b/src/frontend/views/isbn-registry/publisher-ranges/IsbnPublisherRange.jsx
@@ -218,12 +218,12 @@ function IsbnPublisherRange(props) {
                   <FormattedMessage id="ranges.subrange.cancel.text" />
                 </DialogContentText>
               </DialogContent>
-              <DialogActions>
-                <Button onClick={() => setCancelModalIsOpen(false)}>
-                  <FormattedMessage id="common.no" />
-                </Button>
-                <Button onClick={handleDeleteRange}>
+              <DialogActions className="dialogButtons">
+                <Button variant="contained" color="success" onClick={handleDeleteRange}>
                   <FormattedMessage id="common.yes" />
+                </Button>
+                <Button variant="contained" color="error" onClick={() => setCancelModalIsOpen(false)}>
+                  <FormattedMessage id="common.no" />
                 </Button>
               </DialogActions>
             </Dialog>

--- a/src/frontend/views/isbn-registry/publisher-ranges/IsmnPublisherRange.jsx
+++ b/src/frontend/views/isbn-registry/publisher-ranges/IsmnPublisherRange.jsx
@@ -218,12 +218,12 @@ function IsmnPublisherRange(props) {
                   <FormattedMessage id="ranges.subrange.cancel.text" />
                 </DialogContentText>
               </DialogContent>
-              <DialogActions>
-                <Button onClick={() => setCancelModalIsOpen(false)}>
-                  <FormattedMessage id="common.no" />
-                </Button>
-                <Button onClick={handleDeleteRange}>
+              <DialogActions className="dialogButtons">
+                <Button variant="contained" color="success" onClick={handleDeleteRange}>
                   <FormattedMessage id="common.yes" />
+                </Button>
+                <Button variant="contained" color="error" onClick={() => setCancelModalIsOpen(false)}>
+                  <FormattedMessage id="common.no" />
                 </Button>
               </DialogActions>
             </Dialog>

--- a/src/frontend/views/isbn-registry/publishers/IsbnPublisher.jsx
+++ b/src/frontend/views/isbn-registry/publishers/IsbnPublisher.jsx
@@ -209,11 +209,11 @@ function IsbnPublisher(props) {
         {({handleSubmit}) => (
           <form onSubmit={handleSubmit}>
             <div className="updateButtonsContainer">
-              <Button onClick={handleCancel}>
-                <FormattedMessage id="form.button.label.cancel" />
-              </Button>
-              <Button type="submit" variant="contained" color="primary">
+              <Button type="submit" variant="contained" color="success">
                 <FormattedMessage id="form.button.label.update" />
+              </Button>
+              <Button variant="contained" color="error" onClick={handleCancel}>
+                <FormattedMessage id="form.button.label.cancel" />
               </Button>
             </div>
             <div className="listItemSpinner">{dataComponent}</div>

--- a/src/frontend/views/isbn-registry/requests/publications/IsbnPublicationRequest.jsx
+++ b/src/frontend/views/isbn-registry/requests/publications/IsbnPublicationRequest.jsx
@@ -479,9 +479,6 @@ function IsbnPublicationRequest(props) {
           {/* Display if granting identifiers */}
           {isGrantingIdentifiers ? (
             <div className="grantAnIdButtonsContainer">
-              <Button variant="contained" color="error" onClick={handleCancelGrantAnId}>
-                <FormattedMessage id="form.button.label.cancel" />
-              </Button>
               <Button
                 variant="contained"
                 color="primary"
@@ -512,6 +509,9 @@ function IsbnPublicationRequest(props) {
                 ) : (
                   <FormattedMessage id="form.button.label.submit" />
                 )}
+              </Button>
+              <Button variant="contained" color="error" onClick={handleCancelGrantAnId}>
+                <FormattedMessage id="form.button.label.cancel" />
               </Button>
               <Modal
                 open={open}

--- a/src/frontend/views/isbn-registry/requests/publications/IsbnPublicationRequest.jsx
+++ b/src/frontend/views/isbn-registry/requests/publications/IsbnPublicationRequest.jsx
@@ -412,16 +412,16 @@ function IsbnPublicationRequest(props) {
           <form onSubmit={handleSubmit}>
             <div className="updateContainer">
               <div className="updateButtonsContainer">
-                <Button onClick={handleCancel}>
-                  <FormattedMessage id="form.button.label.cancel" />
-                </Button>
                 <Button
                   type="submit"
                   variant="contained"
-                  color="primary"
+                  color="success"
                   disabled={!valid}
                 >
                   <FormattedMessage id="form.button.label.update" />
+                </Button>
+                <Button variant="contained" color="error" onClick={handleCancel}>
+                  <FormattedMessage id="form.button.label.cancel" />
                 </Button>
               </div>
               {/* Display an error message if the form is not valid */}
@@ -542,15 +542,15 @@ function IsbnPublicationRequest(props) {
                     </Typography>
                   ))}
                   <div>
-                    <Button variant="contained" color="error" onClick={handleCloseModal}>
-                      <FormattedMessage id="form.button.label.reject" />
-                    </Button>
                     <Button
                       variant="contained"
                       color="success"
                       onClick={handleSubmitAnId}
                     >
                       <FormattedMessage id="form.button.label.approve" />
+                    </Button>
+                    <Button variant="contained" color="error" onClick={handleCloseModal}>
+                      <FormattedMessage id="form.button.label.reject" />
                     </Button>
                   </div>
                 </Box>
@@ -615,12 +615,12 @@ function IsbnPublicationRequest(props) {
                     <FormattedMessage id="request.publication.copy.approve.description" />
                   </DialogContentText>
                 </DialogContent>
-                <DialogActions>
-                  <Button onClick={() => setCopyModalIsOpen(false)}>
-                    <FormattedMessage id="form.button.label.cancel" />
-                  </Button>
-                  <Button onClick={handleCopyRequest}>
+                <DialogActions className="dialogButtons">
+                  <Button variant="contained" color="success" onClick={handleCopyRequest}>
                     <FormattedMessage id="form.button.label.approve" />
+                  </Button>
+                  <Button variant="contained" color="error" onClick={() => setCopyModalIsOpen(false)}>
+                    <FormattedMessage id="form.button.label.cancel" />
                   </Button>
                 </DialogActions>
               </Dialog>
@@ -683,12 +683,12 @@ function IsbnPublicationRequest(props) {
                     <FormattedMessage id="request.publisher.delete.approve" />
                   </DialogContentText>
                 </DialogContent>
-                <DialogActions>
-                  <Button onClick={() => setDeleteModalIsOpen(false)}>
-                    <FormattedMessage id="form.button.label.cancel" />
-                  </Button>
-                  <Button onClick={handleDeleteRequest}>
+                <DialogActions className="dialogButtons">
+                  <Button variant="contained" color="success" onClick={handleDeleteRequest}>
                     <FormattedMessage id="form.button.label.approve" />
+                  </Button>
+                  <Button variant="contained" color="error" onClick={() => setDeleteModalIsOpen(false)}>
+                    <FormattedMessage id="form.button.label.cancel" />
                   </Button>
                 </DialogActions>
               </Dialog>

--- a/src/frontend/views/isbn-registry/requests/publishers/IsbnPublisherRequest.jsx
+++ b/src/frontend/views/isbn-registry/requests/publishers/IsbnPublisherRequest.jsx
@@ -438,16 +438,16 @@ function IsbnPublisherRequest(props) {
           <form onSubmit={handleSubmit}>
             <div className="updateContainer">
               <div className="updateButtonsContainer">
-                <Button onClick={handleCancel}>
-                  <FormattedMessage id="form.button.label.cancel" />
-                </Button>
                 <Button
                   type="submit"
                   variant="contained"
-                  color="primary"
+                  color="success"
                   disabled={!valid}
                 >
                   <FormattedMessage id="form.button.label.update" />
+                </Button>
+                <Button variant="contained" color="error" onClick={handleCancel}>
+                  <FormattedMessage id="form.button.label.cancel" />
                 </Button>
               </div>
               {/* Display an error message if the form is not valid */}
@@ -530,12 +530,12 @@ function IsbnPublisherRequest(props) {
                   <FormattedMessage id="request.publisher.delete.approve" />
                 </DialogContentText>
               </DialogContent>
-              <DialogActions>
-                <Button onClick={() => setDeleteModalIsOpen(false)}>
-                  <FormattedMessage id="form.button.label.cancel" />
-                </Button>
-                <Button onClick={handleDeleteRequest}>
+              <DialogActions className="dialogButtons">
+                <Button variant="contained" color="success" onClick={handleDeleteRequest}>
                   <FormattedMessage id="form.button.label.approve" />
+                </Button>
+                <Button variant="contained" color="error" onClick={() => setDeleteModalIsOpen(false)}>
+                  <FormattedMessage id="form.button.label.cancel" />
                 </Button>
               </DialogActions>
             </Dialog>

--- a/src/frontend/views/issn-registry/messagetemplates/IssnMessageTemplateForm.jsx
+++ b/src/frontend/views/issn-registry/messagetemplates/IssnMessageTemplateForm.jsx
@@ -143,20 +143,20 @@ function IssnMessageTemplateForm(props) {
             />
             <div className="templateFormButtons">
               <Button
-                type="button"
-                variant="contained"
-                color="primary"
-                onClick={handleCancel}
-              >
-                <FormattedMessage id="form.button.label.cancel" />
-              </Button>
-              <Button
                 disabled={pristine || !valid}
                 type="submit"
                 variant="contained"
                 color="success"
               >
                 <FormattedMessage id="form.button.label.create" />
+              </Button>
+              <Button
+                type="button"
+                variant="contained"
+                color="primary"
+                onClick={handleCancel}
+              >
+                <FormattedMessage id="form.button.label.cancel" />
               </Button>
             </div>
           </form>

--- a/src/frontend/views/issn-registry/publications/IssnPublication.jsx
+++ b/src/frontend/views/issn-registry/publications/IssnPublication.jsx
@@ -309,16 +309,16 @@ function IssnPublication(props) {
             {({handleSubmit, valid}) => (
               <form onSubmit={handleSubmit}>
                 <div className="updateButtonsContainer">
-                  <Button onClick={handleCancel}>
-                    <FormattedMessage id="form.button.label.cancel" />
-                  </Button>
                   <Button
                     type="submit"
                     variant="contained"
-                    color="primary"
+                    color="success"
                     disabled={!valid}
                   >
                     <FormattedMessage id="form.button.label.update" />
+                  </Button>
+                  <Button variant="contained" color="error" onClick={handleCancel}>
+                    <FormattedMessage id="form.button.label.cancel" />
                   </Button>
                 </div>
                 <div className="listItemSpinner">{dataComponent}</div>
@@ -433,12 +433,12 @@ function IssnPublication(props) {
                     <FormattedMessage id="publication.issn.delete.approve" />
                   </DialogContentText>
                 </DialogContent>
-                <DialogActions>
-                  <Button onClick={() => setDeleteModalIsOpen(false)}>
-                    <FormattedMessage id="form.button.label.cancel" />
-                  </Button>
-                  <Button onClick={handleDeletePublication}>
+                <DialogActions className="dialogButtons">
+                  <Button variant="contained" color="success" onClick={handleDeletePublication}>
                     <FormattedMessage id="form.button.label.approve" />
+                  </Button>
+                  <Button variant="contained" color="error" onClick={() => setDeleteModalIsOpen(false)}>
+                    <FormattedMessage id="form.button.label.cancel" />
                   </Button>
                 </DialogActions>
               </Dialog>

--- a/src/frontend/views/issn-registry/publications/IssnPublication.jsx
+++ b/src/frontend/views/issn-registry/publications/IssnPublication.jsx
@@ -308,7 +308,7 @@ function IssnPublication(props) {
           >
             {({handleSubmit, valid}) => (
               <form onSubmit={handleSubmit}>
-                <div className="btnContainer">
+                <div className="updateButtonsContainer">
                   <Button onClick={handleCancel}>
                     <FormattedMessage id="form.button.label.cancel" />
                   </Button>

--- a/src/frontend/views/issn-registry/publishers/IssnPublisher.jsx
+++ b/src/frontend/views/issn-registry/publishers/IssnPublisher.jsx
@@ -188,11 +188,11 @@ function IssnPublisher(props) {
           {({handleSubmit}) => (
             <form onSubmit={handleSubmit}>
               <div className="updateButtonsContainer">
-                <Button onClick={handleCancel}>
-                  <FormattedMessage id="form.button.label.cancel" />
-                </Button>
-                <Button type="submit" variant="contained" color="primary">
+                <Button type="submit" variant="contained" color="success">
                   <FormattedMessage id="form.button.label.update" />
+                </Button>
+                <Button variant="contained" color="error" onClick={handleCancel}>
+                  <FormattedMessage id="form.button.label.cancel" />
                 </Button>
               </div>
               <div className="listItemSpinner">
@@ -260,12 +260,12 @@ function IssnPublisher(props) {
               <FormattedMessage id="publisher.issn.delete.approve" />
             </DialogContentText>
           </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setDeleteModalIsOpen(false)}>
-              <FormattedMessage id="form.button.label.cancel" />
-            </Button>
-            <Button onClick={handleDeletePublisher}>
+          <DialogActions className="dialogButtons">
+            <Button variant="contained" color="success" onClick={handleDeletePublisher}>
               <FormattedMessage id="form.button.label.approve" />
+            </Button>
+            <Button variant="contained" color="error" onClick={() => setDeleteModalIsOpen(false)}>
+              <FormattedMessage id="form.button.label.cancel" />
             </Button>
           </DialogActions>
         </Dialog>

--- a/src/frontend/views/issn-registry/requests/IssnRequest.jsx
+++ b/src/frontend/views/issn-registry/requests/IssnRequest.jsx
@@ -213,16 +213,16 @@ function IssnRequest(props) {
             {({handleSubmit, valid}) => (
               <form onSubmit={handleSubmit}>
                 <div className="updateButtonsContainer">
-                  <Button onClick={handleCancel}>
-                    <FormattedMessage id="form.button.label.cancel" />
-                  </Button>
                   <Button
                     type="submit"
                     variant="contained"
-                    color="primary"
+                    color="success"
                     disabled={!valid}
                   >
                     <FormattedMessage id="form.button.label.update" />
+                  </Button>
+                  <Button variant="contained" color="error" onClick={handleCancel}>
+                    <FormattedMessage id="form.button.label.cancel" />
                   </Button>
                 </div>
                 <div className="listItemSpinner">{dataComponent}</div>
@@ -310,12 +310,12 @@ function IssnRequest(props) {
                 <FormattedMessage id="request.publisher.delete.approve" />
               </DialogContentText>
             </DialogContent>
-            <DialogActions>
-              <Button onClick={() => setDeleteModalIsOpen(false)}>
-                <FormattedMessage id="form.button.label.cancel" />
-              </Button>
-              <Button onClick={handleDeleteRequest}>
+            <DialogActions className="dialogButtons">
+              <Button variant="contained" color="success" onClick={handleDeleteRequest}>
                 <FormattedMessage id="form.button.label.approve" />
+              </Button>
+              <Button variant="contained" color="error" onClick={() => setDeleteModalIsOpen(false)}>
+                <FormattedMessage id="form.button.label.cancel" />
               </Button>
             </DialogActions>
           </Dialog>

--- a/src/frontend/views/issn-registry/requests/IssnRequest.jsx
+++ b/src/frontend/views/issn-registry/requests/IssnRequest.jsx
@@ -212,7 +212,7 @@ function IssnRequest(props) {
           >
             {({handleSubmit, valid}) => (
               <form onSubmit={handleSubmit}>
-                <div className="btnContainer">
+                <div className="updateButtonsContainer">
                   <Button onClick={handleCancel}>
                     <FormattedMessage id="form.button.label.cancel" />
                   </Button>


### PR DESCRIPTION
- Unified order of accept/reject buttons when granting ISBN & ISSN IDs **KBDEV-965**
- Fixed the arrangement of update buttons (update/cancel) **KBDEV-952**
- Fixed the order of address fields in several components (zip & city) **KBDEV-953**
- Fixed the order and unified visual styles of accept/decline, update/cancel, and submit/reject button pairs **KBDEV-992**
- Moved elements in the publication request component according to the superusers request **KBDEV-1063**